### PR TITLE
WIP: Prepare message update feature

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,6 +11,8 @@ if (!\function_exists('pd')) {
             $client = new Client();
         }
 
+        // To not overwrite the last message again and again
+        $client->setLastMessageId();
         return $client;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,6 +17,11 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 class Client
 {
     /**
+     * @var string|null
+     */
+    private $lastMessageId;
+
+    /**
      * @var string
      */
     private $instanceUrl;
@@ -46,7 +51,6 @@ class Client
         $cloner = new VarCloner();
         $cloner->setMaxItems(-1);
         $htmlDumper = new HtmlDumper();
-
 
         foreach ($arguments as $argument) {
             $data = $htmlDumper->dump($cloner->cloneVar($argument), true);
@@ -182,6 +186,8 @@ class Client
 
         \curl_exec($ch);
         \curl_close($ch);
+
+        $this->lastMessageId = $message->getId();
     }
 
     protected function createMessage(): Message
@@ -193,7 +199,7 @@ class Client
                 continue;
             }
 
-            return new Message($this->stripPath($backtrace['file']), $backtrace['line']);
+            return new Message($this->stripPath($backtrace['file']), $backtrace['line'], $this->lastMessageId ?? null);
         }
 
         throw new \RuntimeException('Cannot detect entry point');
@@ -213,7 +219,7 @@ class Client
         $resp = \curl_exec($ch);
         \curl_close($ch);
 
-        return $resp === "1";
+        return $resp === '1';
     }
 
     private function stripPath(string $path): string
@@ -225,5 +231,12 @@ class Client
         }
 
         return $path;
+    }
+
+    public function setLastMessageId(?string $lastMessageId = null): self
+    {
+        $this->lastMessageId = $lastMessageId;
+
+        return $this;
     }
 }

--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -33,9 +33,9 @@ class Message extends Struct
      */
     protected $payloads = [];
 
-    public function __construct(string $fileName, int $lineNumber)
+    public function __construct(string $fileName, int $lineNumber, ?string $uuid = null)
     {
-        $this->uuid = Uuid::randomHex();
+        $this->uuid = $uuid ?? Uuid::randomHex();
         $this->time = \microtime(true);
         $this->origin = new Origin($fileName, $lineNumber);
     }


### PR DESCRIPTION
Just a little idea how to implement the feature to update a message at a later time.

The idea is: The client stores the id of the last sent message and makes sure successive messages get the same id, so the message can be identified and updated on the server side.

My main issue with this solution is the necessary exposure of the `setLastMessageId()` method on the client, it's a leaky abstraction of the underlying implementation.

I'm hoping for some feedback, and maybe some help with the implementation on the server side :)